### PR TITLE
Changed Fatigue and Light Injuries status texts to be configurable

### DIFF
--- a/MechAffinity/Data/Settings.cs
+++ b/MechAffinity/Data/Settings.cs
@@ -29,6 +29,8 @@ namespace MechAffinity.Data
         public int topAffinitiesInTooltipCount = 3;
 
         public bool enablePilotQuirks = false;
+        public string FatiguedTagStatusText = "<b>***PILOT FATIGUED***</b>\nPilot will suffer from Low Spirits if used in combat. The lance will also experience reduced Resolve per turn during combat.\n\n";
+        public string LightInjuryTagSatusText = "<b>***PILOT LIGHT INJURY***</b>\nPilot cannot drop into combat. This pilot requires rest after dropping too frequently while fatigued.\n\n";
         public List<PilotQuirk> pilotQuirks = new List<PilotQuirk>();
         public List<QuirkPool> quirkPools = new List<QuirkPool>();
         public bool playerQuirkPools = false;

--- a/MechAffinity/Patches/SGBarracksRosterSlot.cs
+++ b/MechAffinity/Patches/SGBarracksRosterSlot.cs
@@ -33,12 +33,10 @@ namespace MechAffinity.Patches
             {
                 if (pilot.pilotDef.PilotTags.Contains("pilot_fatigued"))
                 {
-                    Desc +=
-                        "<b>***PILOT FATIGUED***</b>\nPilot will suffer from Low Spirits if used in combat. The lance will also experience reduced Resolve per turn during combat.\n\n";
+                    Desc += Main.settings.FatiguedTagStatusText;
                 }
                 else if (pilot.pilotDef.PilotTags.Contains("pilot_lightinjury"))
-                    Desc +=
-                        "<b>***PILOT LIGHT INJURY***</b>\nPilot cannot drop into combat. This pilot requires rest after dropping too frequently while fatigued.\n\n";
+                    Desc += Main.settings.LightInjuryTagSatusText;
             }
 
             Desc += PilotQuirkManager.Instance.getPilotToolTip(pilot);


### PR DESCRIPTION
Made this change so that the text can be updated to better reflect chosen options in Pilot_Fatigue such as FatigueReducesSkills.

I tried to add a PostFix patch to Pilot_Fatigue to remove those strings and update with new ones while still retaining the mech affinities but I couldn't get I couldn't get an instance of a tooltip that had any text in it, so it just ended up overwriting the tooltip completely and removing mech affinities.

So I figured this was the next best thing. Not ideal, but it works.

Sorry about the duplicate pull requests.