### PR TITLE
Integrated Mech Maintenance By Cost

### DIFF
--- a/MechAffinity/Data/Settings.cs
+++ b/MechAffinity/Data/Settings.cs
@@ -27,7 +27,13 @@ namespace MechAffinity.Data
         public bool trackLowestDecayByStat = false;
         public bool showAllPilotAffinities = true;
         public int topAffinitiesInTooltipCount = 3;
-
+        
+        public bool MechMaintenanceByCost = false;
+        public float MMBC_PercentageOfMechCost = 0.003f;
+        public bool MMBC_CostByTons = false;
+        public int MMBC_cbillsPerTon = 500;
+        public bool MMBC_TonsAdditive = false;
+        
         public bool enablePilotQuirks = false;
         public List<PilotQuirk> pilotQuirks = new List<PilotQuirk>();
         public List<QuirkPool> quirkPools = new List<QuirkPool>();


### PR DESCRIPTION
Integrated MechMaintenanceByCost as an option (default is false). Since the 2 mods aren't compatible without disabling perks in MechAffinity. This gives users the option to use both.

-Added MechMaintenanceByCost variables to settings all mod specific variables except bool MechMaintenanceByCost (default false) receive a prefix of MMBC_
-Updated SimGameState_GetExpenditures for Mech Maintenance By Cost
-Updated SGCaptainsQuartersStatusScreen_RefreshData for Mech Maintenance By Cost