### PR TITLE
Tooltip Fixes

### DIFF
--- a/MechAffinity/Features/PilotQuirkManager.cs
+++ b/MechAffinity/Features/PilotQuirkManager.cs
@@ -169,11 +169,13 @@ namespace MechAffinity
             if (pilot != null && Main.settings.enablePilotQuirks)
             {
                 List<PilotQuirk> pilotQuirks = getQuirks(pilot);
-                ret = "\n";
                 foreach (PilotQuirk quirk in pilotQuirks)
                 {
-                    ret += $"<b>{quirk.quirkName}</b>:\n{quirk.description}\n\n";
+                    if (quirk.quirkName.Length > 0 && quirk.description.Length > 0)
+                        ret += $"<b>{quirk.quirkName}</b>:\n{quirk.description}\n\n";
                 }
+                if (ret.Length > 0)
+                    ret += "\n";
             }
 
             return ret;
@@ -188,7 +190,8 @@ namespace MechAffinity
                 List<PilotQuirk> pilotQuirks = getQuirks(pilot);
                 foreach (PilotQuirk quirk in pilotQuirks)
                 {
-                    ret += $"<b>{quirk.quirkName}:</b>{quirk.description}\n\n";
+                    if (quirk.quirkName.Length > 0 && quirk.description.Length > 0)
+                        ret += $"<b>{quirk.quirkName}:</b>{quirk.description}\n\n";
                 }
             }
 
@@ -204,7 +207,8 @@ namespace MechAffinity
                 List<PilotQuirk> pilotQuirks = getQuirks(pilot);
                 foreach (PilotQuirk quirk in pilotQuirks)
                 {
-                    ret += $"{quirk.quirkName}\n\n{quirk.description}\n\n";
+                    if (quirk.quirkName.Length > 0 && quirk.description.Length > 0)
+                        ret += $"{quirk.quirkName}\n\n{quirk.description}\n\n";
                 }
             }
 

--- a/MechAffinity/Patches/SGBarracksRosterSlot.cs
+++ b/MechAffinity/Patches/SGBarracksRosterSlot.cs
@@ -39,7 +39,7 @@ namespace MechAffinity.Patches
             }
 
             Desc += PilotQuirkManager.Instance.getPilotToolTip(pilot);
-            Desc += "<b>Pilot Affinities:</b>\n\n";
+            Desc += "<b>Pilot Affinities:</b>\n";
             Desc += PilotAffinityManager.Instance.getPilotToolTip(pilot);
 
             var descriptionDef = new BaseDescriptionDef("Tags", pilot.Callsign, Desc, null);


### PR DESCRIPTION
-Fixed triple \n after "Pilot Affinities"
    -Because PilotAffinityManager.getPilotToolTip() starts it's return string with \n, "<b>Pilot Affinities:</b>\n" only needs 1 \n to get the presumably desired effect
-Fixed \n before "Pilot Affinities" if Pilot Quirks are enabled but pilot has no quirks
-Fixed \n between Pilot Tag Tooltips and Pilot Quirk Tooltips, to avoid a break between legacy quirks and mechaffinity quirks 
-Updated PilotQuirkManager.getPilotToolTip(), PilotQuirkManager.getRoninHiringHallDescription(), and PilotQuirkManager.getRegularHiringHallDescription() with length > 0 checks for Pilot Quirk names and descriptions
    -This Allow "hidden" quirks ,ie quirks with name and description set to ""

Current MechAffinity with legacy and MechAffinity pilot quirks and a "hidden" pilot quirk:
![current_small](https://user-images.githubusercontent.com/15960688/117517711-d59a8580-af6a-11eb-914d-34cd4be35691.png)
Same but with the above changes:
![fixed-small](https://user-images.githubusercontent.com/15960688/117517755-f5ca4480-af6a-11eb-9676-11f82d07b4c6.png)

