### PR TITLE
settings storage improvements

### DIFF
--- a/MechAffinity/Data/AffinityLevel.cs
+++ b/MechAffinity/Data/AffinityLevel.cs
@@ -8,6 +8,9 @@ namespace MechAffinity.Data
 {
     class AffinityLevel
     {
+
+        [JsonProperty(Order = -1)]
+        public string id;
         public int missionsRequired = 0;
         public string levelName = "sample";
         public string decription = "";

--- a/MechAffinity/Data/ChassisSpecificAffinity.cs
+++ b/MechAffinity/Data/ChassisSpecificAffinity.cs
@@ -8,11 +8,8 @@ using Newtonsoft.Json;
 
 namespace MechAffinity.Data
 {
-    class ChassisSpecificAffinity
-    {
+    class ChassisSpecificAffinity: LeveledAffinity {
         public List<string> chassisNames = new List<string> ();
-        public List<AffinityLevel> affinityLevels = new List<AffinityLevel>();
-        
         [JsonConverter(typeof(StringEnumConverter))]
         public EIdType idType = EIdType.AssemblyVariant;
     }

--- a/MechAffinity/Data/Settings.cs
+++ b/MechAffinity/Data/Settings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,11 +10,6 @@ namespace MechAffinity.Data
     class Settings
     {
         public bool debug = false;
-        public List<AffinityLevel> globalAffinities = new List<AffinityLevel>();
-        public List<ChassisSpecificAffinity> chassisAffinities = new List<ChassisSpecificAffinity>();
-        public List<QuirkAffinity> quirkAffinities = new List<QuirkAffinity>();
-        public List<TaggedAffinity> taggedAffinities = new List<TaggedAffinity>();
-        public List<PrefabOverride> prefabOverrides = new List<PrefabOverride>();
         public int missionsBeforeDecay = -1;
         public int lowestPossibleDecay = 0;
         public int removeAffinityAfter = 100;
@@ -29,13 +25,142 @@ namespace MechAffinity.Data
         public int topAffinitiesInTooltipCount = 3;
 
         public bool enablePilotQuirks = false;
-        public List<PilotQuirk> pilotQuirks = new List<PilotQuirk>();
-        public List<QuirkPool> quirkPools = new List<QuirkPool>();
         public bool playerQuirkPools = false;
         public bool pqArgoAdditive = true;
         public bool pqArgoMultiAutoAdjust = true;
         public float pqArgoMin = 0.0f;
-        
+
+        [JsonIgnore]
+        private Dictionary<string, AffinityLevel> globalAffinities_dict = new Dictionary<string, AffinityLevel>();
+        [JsonIgnore]
+        private Dictionary<string, ChassisSpecificAffinity> chassisAffinities_dict = new Dictionary<string, ChassisSpecificAffinity>();
+        [JsonIgnore]
+        private Dictionary<string, QuirkAffinity> quirkAffinities_dict = new Dictionary<string, QuirkAffinity>();
+        [JsonIgnore]
+        private Dictionary<string, TaggedAffinity> taggedAffinities_dict = new Dictionary<string, TaggedAffinity>();
+        [JsonIgnore]
+        private Dictionary<string, PilotQuirk> pilotQuirks_dict = new Dictionary<string, PilotQuirk>();
+
+
+        public List<QuirkPool> quirkPools = new List<QuirkPool>();
         public List<PilotTooltipTag> pqTooltipTags = new List<PilotTooltipTag>();
+
+        public List<PilotQuirk> pilotQuirks = new List<PilotQuirk>();
+        public List<AffinityLevel> globalAffinities = new List<AffinityLevel>();
+        public List<ChassisSpecificAffinity> chassisAffinities = new List<ChassisSpecificAffinity>();
+        public List<QuirkAffinity> quirkAffinities = new List<QuirkAffinity>();
+        public List<TaggedAffinity> taggedAffinities = new List<TaggedAffinity>();
+
+        public List<PrefabOverride> prefabOverrides = new List<PrefabOverride>();
+    private static int unique_id_counter = 0;
+    private static HashSet<string> used_unique_Ids = new HashSet<string>();
+    public static string createId(string pattern) { return pattern.Replace(" ","_").Replace(".","_").Replace("!","_").Replace("!", "_").Replace("@", "_"); }
+    public static string createUniqueId(string pattern = null) {
+      if (string.IsNullOrEmpty(pattern)) { pattern = "please_fill_it_with_some_unique_id"; }
+      else{ pattern = Settings.createId(pattern); }
+      string result = pattern;
+      while (used_unique_Ids.Contains(result)) { 
+        result = string.Format("{0}_{1}", pattern, unique_id_counter);
+        ++unique_id_counter;
+      };
+      used_unique_Ids.Add(result);
+      return result;
+    }
+    public void Merge_globalAffinities(List<AffinityLevel> add_globalAffinities) {
+      foreach (AffinityLevel new_lvl in add_globalAffinities) {
+        if(this.globalAffinities_dict.TryGetValue(new_lvl.id, out AffinityLevel old_lvl)) {
+          old_lvl.affinities.AddRange(new_lvl.affinities);
+          old_lvl.levelName = new_lvl.levelName;
+          old_lvl.decription = new_lvl.decription;
+          old_lvl.effectData.AddRange(new_lvl.effectData);
+        } else {
+          this.globalAffinities.Add(new_lvl);
+          this.globalAffinities_dict.Add(new_lvl.id, new_lvl);
+        }
+      }
+    }
+    public void Merge_chassisAffinities(List<ChassisSpecificAffinity> add_chassisAffinities) {
+      foreach (ChassisSpecificAffinity new_affinity in add_chassisAffinities) {
+        if (this.chassisAffinities_dict.TryGetValue(new_affinity.id, out ChassisSpecificAffinity old_affinity)) {
+          old_affinity.Merge(new_affinity.affinityLevels);
+          old_affinity.chassisNames.AddRange(new_affinity.chassisNames);
+        } else {
+          this.chassisAffinities.Add(new_affinity);
+          this.chassisAffinities_dict.Add(new_affinity.id, new_affinity);
+        }
+      }
+    }
+    public void Merge_quirkAffinities(List<QuirkAffinity> add_quirkAffinities) {
+      foreach (QuirkAffinity new_affinity in add_quirkAffinities) {
+        if (this.quirkAffinities_dict.TryGetValue(new_affinity.id, out QuirkAffinity old_affinity)) {
+          old_affinity.Merge(new_affinity.affinityLevels);
+          old_affinity.quirkNames.AddRange(new_affinity.quirkNames);
+        } else {
+          this.quirkAffinities.Add(new_affinity);
+          this.quirkAffinities_dict.Add(new_affinity.id, new_affinity);
+        }
+      }
+    }
+    public void Merge_taggedAffinities(List<TaggedAffinity> add_taggedAffinities) {
+      foreach (TaggedAffinity new_affinity in add_taggedAffinities) {
+        if (this.taggedAffinities_dict.TryGetValue(new_affinity.id, out TaggedAffinity old_affinity)) {
+          old_affinity.Merge(new_affinity.affinityLevels);
+          old_affinity.tag = new_affinity.tag;
+        } else {
+          this.taggedAffinities.Add(new_affinity);
+          this.taggedAffinities_dict.Add(new_affinity.id, new_affinity);
+        }
+      }
+    }
+    public void Merge_pilotQuirks(List<PilotQuirk> add_pilotQuirks) {
+      foreach (PilotQuirk new_affinity in add_pilotQuirks) {
+        if (this.pilotQuirks_dict.TryGetValue(new_affinity.tag, out PilotQuirk old_affinity)) {
+          old_affinity.quirkEffects.AddRange(new_affinity.quirkEffects);
+          old_affinity.effectData.AddRange(new_affinity.effectData);
+        } else {
+          this.pilotQuirks.Add(new_affinity);
+          this.pilotQuirks_dict.Add(new_affinity.tag, new_affinity);
+        }
+      }
+    }
+    public void Merge(Settings add_settings) {
+      this.Merge_pilotQuirks(add_settings.pilotQuirks);
+      this.Merge_globalAffinities(add_settings.globalAffinities);
+      this.Merge_chassisAffinities(add_settings.chassisAffinities);
+      this.Merge_quirkAffinities(add_settings.quirkAffinities);
+      this.Merge_taggedAffinities(add_settings.taggedAffinities);
+    }
+    public bool Check(string filename) {
+      bool result = false;
+      foreach (PilotQuirk item in this.pilotQuirks) {
+        if (string.IsNullOrEmpty(item.tag)) { result = true; item.tag = createUniqueId(item.tag); }
+        if (globalAffinities_dict.ContainsKey(item.tag)) { throw new Exception("pilotQuirk id duplication detected " + item.tag + " in file " + filename); }
+        pilotQuirks_dict.Add(item.tag, item);
+      }
+      foreach (AffinityLevel item in this.globalAffinities) {
+        if (string.IsNullOrEmpty(item.id)) { result = true; item.id = createUniqueId(item.levelName); }
+        if (globalAffinities_dict.ContainsKey(item.id)) { throw new Exception("globalAffinity id duplication detected "+ item.id + " in file " + filename); }
+        globalAffinities_dict.Add(item.id, item);
+      }
+      foreach (ChassisSpecificAffinity item in this.chassisAffinities) {
+        if (string.IsNullOrEmpty(item.id)) { result = true; item.id = createUniqueId(); }
+        if (chassisAffinities_dict.ContainsKey(item.id)) { throw new Exception("chassisAffinity id duplication detected " + item.id + " in file " + filename); }
+        chassisAffinities_dict.Add(item.id, item);
+        if (item.Check(filename)) { result = true; }
+      }
+      foreach (QuirkAffinity item in this.quirkAffinities) {
+        if (string.IsNullOrEmpty(item.id)) { result = true; item.id = createUniqueId(); }
+        if (quirkAffinities_dict.ContainsKey(item.id)) { throw new Exception("quirkAffinities id duplication detected " + item.id + " in file " + filename); }
+        quirkAffinities_dict.Add(item.id, item);
+        if (item.Check(filename)) { result = true; }
+      }
+      foreach (TaggedAffinity item in this.taggedAffinities) {
+        if (string.IsNullOrEmpty(item.id)) { result = true; item.id = createUniqueId(); }
+        if (taggedAffinities_dict.ContainsKey(item.id)) { throw new Exception("taggedAffinities id duplication detected " + item.id + " in file " + filename); }
+        taggedAffinities_dict.Add(item.id, item);
+        if (item.Check(filename)) { result = true; }
+      }
+      return result;
+    }
     }
 }

--- a/MechAffinity/Data/quirkAffinity.cs
+++ b/MechAffinity/Data/quirkAffinity.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,9 +7,37 @@ using System.Threading.Tasks;
 
 namespace MechAffinity.Data
 {
-    class QuirkAffinity
-    {
+    class LeveledAffinity {
+      [JsonProperty(Order = -2)]
+      public string id;
+      [JsonProperty(Order = -1)]
+      public List<AffinityLevel> affinityLevels = new List<AffinityLevel>();
+      [JsonIgnore]
+      public Dictionary<string, AffinityLevel> affinityLevels_dict = new Dictionary<string, AffinityLevel>();
+      public bool Check(string filename) {
+        bool result = false;
+        foreach (AffinityLevel lvl in this.affinityLevels) {
+          if (string.IsNullOrEmpty(lvl.id)) { result = true; lvl.id = Settings.createUniqueId(lvl.levelName); }
+          if (affinityLevels_dict.ContainsKey(lvl.id)) { throw new Exception("AffinityLevel id duplication detected " + lvl.id + " in file " + filename); }
+          affinityLevels_dict.Add(lvl.id, lvl);
+        }
+        return result;
+      }
+      public void Merge(List<AffinityLevel> levels) {
+        foreach (AffinityLevel new_lvl in levels) {
+          if (this.affinityLevels_dict.TryGetValue(new_lvl.id, out AffinityLevel old_lvl)) {
+            old_lvl.affinities.AddRange(new_lvl.affinities);
+            old_lvl.levelName = new_lvl.levelName;
+            old_lvl.decription = new_lvl.decription;
+            old_lvl.effectData.AddRange(new_lvl.effectData);
+          } else {
+            this.affinityLevels.Add(new_lvl);
+            this.affinityLevels_dict.Add(new_lvl.id, new_lvl);
+          }
+        }
+      }
+  }
+    class QuirkAffinity: LeveledAffinity {
         public List<string> quirkNames = new List<string>();
-        public List<AffinityLevel> affinityLevels = new List<AffinityLevel>();
     }
 }

--- a/MechAffinity/Features/PilotAffinityManager.cs
+++ b/MechAffinity/Features/PilotAffinityManager.cs
@@ -65,8 +65,10 @@ namespace MechAffinity
             pilotStatMap = new Dictionary<string, List<string>>();
             pilotNoDeployStatMap = new Dictionary<string, List<string>>();
             overloads = new Dictionary<string, EIdType>();
+            Main.modLog.LogMessage("chassisAffinities:"+ Main.settings.chassisAffinities.Count);
             foreach (ChassisSpecificAffinity chassisSpecific in Main.settings.chassisAffinities)
             {
+                Main.modLog.LogMessage(" id:"+ chassisSpecific.id);
                 foreach (string chassisName in chassisSpecific.chassisNames)
                 {
                     chassisAffinities.Add(chassisName, chassisSpecific.affinityLevels);
@@ -77,6 +79,7 @@ namespace MechAffinity
                 }
                 foreach (AffinityLevel affinityLevel in chassisSpecific.affinityLevels)
                 {
+                    Main.modLog.LogMessage("  level:" + affinityLevel.id);
                     levelDescriptors[affinityLevel.levelName] = new DescriptionHolder(affinityLevel.levelName, affinityLevel.decription, affinityLevel.missionsRequired);
                     foreach (JObject jObject in affinityLevel.effectData)
                     {
@@ -86,9 +89,11 @@ namespace MechAffinity
                     }
                 }
             }
+            Main.modLog.LogMessage("taggedAffinities:" + Main.settings.taggedAffinities.Count);
             foreach (TaggedAffinity tagged in Main.settings.taggedAffinities)
             {
                 tagsWithAffinities.Add(tagged.tag);
+                Main.modLog.LogMessage(" id:"+ tagged.id);
                 foreach (string chassisName in tagged.chassisNames)
                 {
                     taggedAffinities.Add($"{tagged.tag}={chassisName}", tagged.affinityLevels);
@@ -103,6 +108,7 @@ namespace MechAffinity
                 foreach (AffinityLevel affinityLevel in tagged.affinityLevels)
                 {
                     levelDescriptors[affinityLevel.levelName] = new DescriptionHolder(affinityLevel.levelName, affinityLevel.decription, affinityLevel.missionsRequired);
+                    Main.modLog.LogMessage("  level:" + affinityLevel.id);
                     foreach (JObject jObject in affinityLevel.effectData)
                     {
                         EffectData effectData = new EffectData();
@@ -111,14 +117,17 @@ namespace MechAffinity
                     }
                 }
             }
+            Main.modLog.LogMessage("quirkAffinities:" + Main.settings.quirkAffinities.Count);
             foreach (QuirkAffinity quirkAffinity in Main.settings.quirkAffinities)
             {
+                Main.modLog.LogMessage(" id:"+ quirkAffinity.id);
                 foreach (string quirkName in quirkAffinity.quirkNames)
                 {
                     quirkAffinities.Add(quirkName, quirkAffinity.affinityLevels);
                 }
                 foreach (AffinityLevel affinityLevel in quirkAffinity.affinityLevels)
                 {
+                    Main.modLog.LogMessage("  level:" + affinityLevel.id);
                     levelDescriptors[affinityLevel.levelName] = new DescriptionHolder(affinityLevel.levelName, affinityLevel.decription, affinityLevel.missionsRequired);
                     foreach (JObject jObject in affinityLevel.effectData)
                     {
@@ -128,8 +137,10 @@ namespace MechAffinity
                     }
                 }
             }
+            Main.modLog.LogMessage("globalAffinities:" + Main.settings.globalAffinities.Count);
             foreach (AffinityLevel affinity in Main.settings.globalAffinities)
             {
+                Main.modLog.LogMessage(" id:"+ affinity.id);
                 foreach (JObject jObject in affinity.effectData)
                 {
                     EffectData effectData = new EffectData();

--- a/MechAffinity/Main.cs
+++ b/MechAffinity/Main.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json;
 using MechAffinity.Data;
 using Harmony;
 using System.Reflection;
+using BattleTech;
 
 namespace MechAffinity
 {
@@ -16,20 +17,29 @@ namespace MechAffinity
         internal static Logger modLog;
         internal static Settings settings;
         internal static string modDir;
-
-        public static void Init(string modDirectory, string settingsJSON)
-        {
-
-            modDir = modDirectory;
-            modLog = new Logger(modDir, "MechAffinity", true);
-
-            try
-            {
-                using (StreamReader reader = new StreamReader($"{modDir}/settings.json"))
-                {
-                    string jdata = reader.ReadToEnd();
-                    settings = JsonConvert.DeserializeObject<Settings>(jdata);
+        internal static readonly string AffinitiesDefinitionTypeName = "AffinitiesDef";
+        public static void FinishedLoading(List<string> loadOrder, Dictionary<string, Dictionary<string, VersionManifestEntry>> customResources) {
+          foreach (var customResource in customResources) {
+            modLog.LogMessage("customResource:" + customResource.Key);
+            if (customResource.Key == AffinitiesDefinitionTypeName) {
+              foreach (var custMechRep in customResource.Value) {
+                try {
+                  modLog.LogMessage("Path:" + custMechRep.Value.FilePath);
+                  Settings add_settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(custMechRep.Value.FilePath));
+                  if(add_settings.Check(custMechRep.Value.FilePath)){
+                    File.WriteAllText(custMechRep.Value.FilePath, JsonConvert.SerializeObject(settings, Formatting.Indented));
+                    add_settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText(custMechRep.Value.FilePath));
+                  }
+                  settings.Merge(add_settings);
+                } catch (Exception ex) {
+                  modLog.LogException(ex);
                 }
+              }
+            }
+          }
+          try {
+                
+                
                 PilotAffinityManager.Instance.initialize();
                 PilotQuirkManager.Instance.initialize();
 
@@ -38,6 +48,18 @@ namespace MechAffinity
             catch (Exception ex)
             {
                 modLog.LogException(ex);
+            }
+        }
+
+        public static void Init(string modDirectory, string settingsJSON)
+        {
+
+            modDir = modDirectory;
+            modLog = new Logger(modDir, "MechAffinity", true);
+            settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText($"{modDir}/settings.json")); //if we had failed to read settings it is useless to proceed. Better notify ModTek instead.
+            if (settings.Check($"{modDir}/settings.json")) {
+                File.WriteAllText($"{modDir}/settings.json",JsonConvert.SerializeObject(settings, Formatting.Indented));
+                settings = JsonConvert.DeserializeObject<Settings>(File.ReadAllText($"{modDir}/settings.json"));
             }
 
             var harmony = HarmonyInstance.Create("ca.jwolf.MechAffinity");

--- a/MechAffinity/Main.cs
+++ b/MechAffinity/Main.cs
@@ -50,6 +50,14 @@ namespace MechAffinity
                 modLog.LogException(ex);
             }
         }
+        public static void FinishedLoading(List<string> loadOrder) {
+          try {
+            PilotAffinityManager.Instance.initialize();
+            PilotQuirkManager.Instance.initialize();
+          }catch (Exception ex){
+            modLog.LogException(ex);
+          }
+        }
 
         public static void Init(string modDirectory, string settingsJSON)
         {

--- a/MechAffinity/Properties/AssemblyInfo.cs
+++ b/MechAffinity/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]


### PR DESCRIPTION
1. Now it is possible to load pilotQuirks, globalAffinities, chassisAffinities, quirkAffinities and taggedAffinities from files other than settings.json using ModTek's custom resources infrastructure "AffinitiesDef".
2. Now every affinity and level should have id. 