### PR TITLE
Mech Affinities summary for affinity overflow.

### DIFF
--- a/MechAffinity/Data/Settings.cs
+++ b/MechAffinity/Data/Settings.cs
@@ -24,6 +24,11 @@ namespace MechAffinity.Data
         public bool showAllPilotAffinities = true;
         public int topAffinitiesInTooltipCount = 3;
 
+        /// <summary>
+        /// For any mech affinities beyond the topAffinitiesInTooltipCount, show a one line summary.
+        /// </summary>
+        public bool showRemainingAffinitiesSummary = false;
+
         public bool enablePilotQuirks = false;
         public bool playerQuirkPools = false;
         public bool pqArgoAdditive = true;

--- a/MechAffinity/Data/Settings.cs
+++ b/MechAffinity/Data/Settings.cs
@@ -27,7 +27,7 @@ namespace MechAffinity.Data
         /// <summary>
         /// For any mech affinities beyond the topAffinitiesInTooltipCount, show a one line summary.
         /// </summary>
-        public bool showRemainingAffinitiesSummary = false;
+        public bool showRemainingAffinitiesSummary = true;
 
         public bool enablePilotQuirks = false;
         public bool playerQuirkPools = false;

--- a/MechAffinity/Features/ChassisLevel.cs
+++ b/MechAffinity/Features/ChassisLevel.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MechAffinity
+{
+    public class ChassisLevel
+    {
+        /// <summary>
+        /// The internal key for the chassis
+        /// </summary>
+        public string ChassisId { get; set; }
+
+        /// <summary>
+        /// The name of the Chassis (e.g. Griffin) 
+        /// </summary>
+        public string ChassisName { get; set; }
+
+        /// <summary>
+        /// The the levels text for the chassis.
+        /// e.g.:  Comfortable (1/10)
+        /// </summary>
+        public List<string> LevelTextLines { get; set; }
+
+        /// <summary>
+        /// The number of deployments the pilot has had for this chassis
+        /// </summary>
+        public int DeploymentCount { get; set; }
+    }
+}

--- a/MechAffinity/MechAffinity.csproj
+++ b/MechAffinity/MechAffinity.csproj
@@ -49,21 +49,27 @@
   <ItemGroup>
     <Reference Include="0Harmony">
       <HintPath>D:\SteamLibrary\steamapps\common\BATTLETECH\Mods\ModTek\0Harmony.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>D:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CustomComponents">
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\Mods\CustomComponents\CustomComponents.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="CustomSalvage">
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\Mods\CustomSalvage\CustomSalvage.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="LewdableTanks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>D:\RtMasterCache\RtCache\LewdableTanks\LewdableTanks.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>D:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Newtonsoft.Json.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -76,18 +82,22 @@
     <Reference Include="Unity.TextMeshPro, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>S:\SteamLibrary\steamapps\common\BATTLETECH\BattleTech_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MechAffinity/MechAffinity.csproj
+++ b/MechAffinity/MechAffinity.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Data\Settings.cs" />
     <Compile Include="Data\TaggedAffinity.cs" />
     <Compile Include="Features\BaseEffectManager.cs" />
+    <Compile Include="Features\ChassisLevel.cs" />
     <Compile Include="Features\PilotAffinityManager.cs" />
     <Compile Include="Features\PilotQuirkManager.cs" />
     <Compile Include="Features\PilotRandomizerManager.cs" />

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ example:
     "decayByModulo" : false,
     "defaultDaysBeforeSimDecay" : -1,
     "topAffinitiesInTooltipCount" : 3,
+    "showRemainingAffinitiesSummary" : false,
     "showQuirks" : false,
     "showDescriptionsOnChassis" : false,
     "trackSimDecayByStat" : true,
@@ -58,6 +59,8 @@ manipulate this value by changing the company stat `MaSimDaysDecayModulator`. se
 setting value will always be used
 
 `topAffinitiesInTooltipCount` : the number of mechs to show affinity about in the pilot tooltip, if the pilot has affinities with more mechs than this, mechs with the fewest affinities will be dropped from display
+
+`showRemainingAffinitiesSummary` : if true, instead of dropping any mech affinities that are beyond the `topAffinitiesInTooltipCount` a one line summary for the affinity will be shown.
 
 `showQuirks` : when true, quirk affinities that are assiocated with a mech will be shown in the mechbay description of the mech in addition to any chassis specific affinities
 


### PR DESCRIPTION
New Features:

Added showRemainingAffinitiesSummary.  Instead of dropping
affinities that are not included in the topAffinitiesInTooltipCount list,
a single line summary showing the chassis name and deployment count
is displayed.

For example "Griffin (2)"

Added showRemainingAffinitiesSummary in settings for the feature with
the default of disabled.

Changes:

Changed mech affinity list to exclude any mechs that have zero
affinity.

Minor re factor of getPilotToolTip.  Required as the previous code
depended on the chassisValues to match the
affinities list.

Added showRemainingAffinitiesSummary to docs.